### PR TITLE
Add MeterCall (new-layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,3 +484,5 @@ This repository serves **2,500+ developers** building production AI agents. Help
 <strong>Building the future of AI agents, one contribution at a time.</strong><br>
 <em>Powered by Google ADK • Curated by the community</em>
 </div>
+
+- [MeterCall](https://metercall.ai/?v=a&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** The new layer of the internet. 21M APIs. 727 modules. One prompt.
- **URL:** https://metercall.ai/?v=a&src=github
- **Why it belongs here:** Curated collection of AI agents built with Google’s Agent Development Kit (ADK): templates, best practices, and production-ready examples for research, business, automation, education, and more.

Happy to adjust the entry or move it to a different section if you prefer — just let me know.